### PR TITLE
correção do cursor

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -149,6 +149,7 @@ span.subheading {
   height: 10em;
   margin: 0;
   padding: 0 0 15px 0;
+  cursor: pointer;
 }
 @media (min-width: 300px) {
   #big-logo {


### PR DESCRIPTION
Uso o Google Chrome `versão 43.0.2357.65 m`, e ao passar o mouse em [logo.png](https://github.com/karenkgs/NaoMeCalo/blob/master/img/logo.png), percebi que o cursor fica como: [zoom-in](http://www.w3schools.com/cssref/playit.asp?filename=playcss_cursor&preval=zoom-in), então adicionei `cursor: pointer;` em  [custom.css](https://github.com/karenkgs/NaoMeCalo/blob/master/css/custom.css), para que ele fique como: [pointer](http://www.w3schools.com/cssref/playit.asp?filename=playcss_cursor&preval=pointer).
